### PR TITLE
use es6 for dapp building

### DIFF
--- a/core/digital-twin-lib/dbcp.json
+++ b/core/digital-twin-lib/dbcp.json
@@ -9,11 +9,11 @@
       "files": [
         "lib.digital-twin.js"
       ],
-      "origin": "QmRanRi7f7T89JFmnj5duZi4Mj8j4zbyyyTmNJr4xJgbU4",
+      "origin": "QmVAK55MpegtP3v25CZw2bpeGG9nz5NVVPfNUKNhgKGq6F",
       "primaryColor": "#004f7d",
       "secondaryColor": "#f9f9ff",
       "standalone": true,
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "Shared library for digital-twins and data-containers.",
@@ -43,7 +43,8 @@
       "1.6.1": "QmS1CTMuRYeVuY16S7dzZdsibuBn7hoedAYewpSsH3BKbd",
       "1.7.0": "QmXnr36JG81t4dmNv3JC81BYHgZkN2TNb1B999hj6oArHk",
       "1.7.1": "QmXPGndKTS6Q5yqcCcX4RbxGWwRDCQMeKWU46Q9XidnpW6",
-      "1.8.0": "QmY17NPChKzcqi9vV7gRyK5Xghjwzgm2sYLb9bA1Y78hMz"
+      "1.8.0": "QmY17NPChKzcqi9vV7gRyK5Xghjwzgm2sYLb9bA1Y78hMz",
+      "2.0.0": "QmaSq6AErTose8M1WdDbMYFHYNGYDV7svGKAZgkAmYXsek"
     }
   }
 }

--- a/core/digital-twin-lib/tsconfig.json
+++ b/core/digital-twin-lib/tsconfig.json
@@ -6,6 +6,12 @@
     "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
   "extends": "../../tsconfig.json",
-  "include": ["./src/**/*", "./src/**/*.json"],
-  "references": [{ "path": "../ui.libs" }, { "path": "../evancore.vue.libs" }]
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.json"
+  ],
+  "references": [
+    { "path": "../../core/evancore.vue.libs" },
+    { "path": "../../core/ui.libs" }
+  ]
 }

--- a/core/evan.bootstrap.libs/dbcp.json
+++ b/core/evan.bootstrap.libs/dbcp.json
@@ -8,11 +8,11 @@
         "evan.bootstrap.libs.js",
         "evan.bootstrap.libs.css"
       ],
-      "origin": "QmPmDZCFF9n5Kh1a4FfANid7GrNUzvFRiKe5h56Dz7StAh",
+      "origin": "QmcMbJ3todcWE1jKMdWhwTAUzChQowcXGvMom2xXirUuTy",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "",
@@ -33,7 +33,7 @@
     ],
     "version": "4.3.1",
     "versions": {
-      "4.3.1": "QmVmMGFraKofa3PKMKiohSejxSkbxeYAhHCueBUiuadyC3"
+      "4.3.1": "Qme6ypZe8BQvzXDM2tw1McMmdWz4MB3Lj41swoZTPhYjtz"
     }
   }
 }

--- a/core/evan.bootstrap.libs/tsconfig.json
+++ b/core/evan.bootstrap.libs/tsconfig.json
@@ -1,25 +1,13 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "paths": {},
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*"
+    "./src/**/*",
+    "../../scripts/dapp/vue-shim.d.ts"
   ]
 }

--- a/core/evan.bootstrap.libs/tsconfig.json
+++ b/core/evan.bootstrap.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.json"
   ]
 }

--- a/core/evancore.vue.libs/dbcp.json
+++ b/core/evancore.vue.libs/dbcp.json
@@ -22,11 +22,11 @@
         "evancore.vue.libs.js",
         "evancore.vue.libs.css"
       ],
-      "origin": "QmWGN8ehFNUukqdmi5ToYhhou9ufVo3odwWJh7szzRfZuF",
+      "origin": "QmV1DY3zSVPhJXhH4TWitippzYdUY4geXnw1DTh1aiULns",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "",
@@ -60,7 +60,7 @@
       "1.6.0": "QmVdyNw3WbY3pmYHLyiVBtNRrrHqToL3JuNp7AFzrmHtEC",
       "1.7.0": "Qmc2UaDBLgZDAmXD5rguaufaL6w7kUuRRkx1c2NcwDZL6F",
       "1.8.0": "QmPvoqmRqGeFHwHGZfN8HWNwvByNzkMV6DFnY81wZipkcb",
-      "1.9.0": "Qmc4QjpsQFfafauDcMoWc7xhtcN9UNdVyfZW7hp4WdRYwS"
+      "1.9.0": "QmRDNQfFQhMDt4JjfF76o2cQrTD1sANnDSWpbMXWrsuPJt"
     }
   }
 }

--- a/core/evancore.vue.libs/src/components/forms/files/files.vue
+++ b/core/evancore.vue.libs/src/components/forms/files/files.vue
@@ -90,7 +90,7 @@
       @drop="hovered = false"
     >
       <input
-        id="file-input-upload"
+        :id="id ? id : 'file-input-upload'"
         type="file"
         multiple
         :accept="accept"

--- a/core/evancore.vue.libs/src/vue-core.ts
+++ b/core/evancore.vue.libs/src/vue-core.ts
@@ -24,8 +24,7 @@ import Vuex from 'vuex';
 import vuexI18n from 'vuex-i18n';
 
 // setup moment locales
-// const moment = require('moment').default;
-import * as moment from 'moment';
+import moment from 'moment';
 
 // import evan libs
 import * as dappBrowser from '@evan.network/ui-dapp-browser';
@@ -37,7 +36,7 @@ import { ComponentRegistrationInterface, EvanVueOptionsInterface } from './inter
 import { getDomainName } from './utils';
 import { initializeRouting } from './routing';
 
-/******************************************** functions *******************************************/
+/** ****************************************** functions ****************************************** */
 /**
  * Starts an evan vue dapp and wraps all start functionalities.
  *
@@ -53,8 +52,8 @@ export async function initializeVue(options: EvanVueOptionsInterface) {
     Vue.config.silent = true;
   }
 
-  // never replace the full container, other elements can be placed within this container directly
-  //  => create new child element
+  /* never replace the full container, other elements can be placed within this container directly
+      => create new child element */
   if (options.container === document.body) {
     options.container = document.createElement('div');
     document.body.appendChild(options.container);
@@ -70,9 +69,9 @@ export async function initializeVue(options: EvanVueOptionsInterface) {
 
   // load the vue evan core to get its origin and access the images
   const vueCoreDbcp = await dappBrowser.System
-    .import(`ui.libs.${ getDomainName() }!ens`);
+    .import(`ui.libs.${getDomainName()}!ens`);
   const uiLibBaseUrl = dappBrowser.dapp.getDAppBaseUrl(vueCoreDbcp,
-    `${ vueCoreDbcp.name }.${ getDomainName() }`);
+    `${vueCoreDbcp.name}.${getDomainName()}`);
 
   // initialize VueX
   Vue.use(Vuex);
@@ -85,31 +84,31 @@ export async function initializeVue(options: EvanVueOptionsInterface) {
         profile: {
           selectedSharedContacts: null,
         },
-        swipePanel: ''
+        swipePanel: '',
       },
       isLoggedin: false,
       ...options.state,
     },
     mutations: {
-      setSelectedSharedContacts (state, contacts = null) {
+      setSelectedSharedContacts(state, contacts = null) {
         state.uiState.profile.selectedSharedContacts = contacts;
       },
-      toggleSidePanel (state, type = 'left') {
+      toggleSidePanel(state, type = 'left') {
         // open the desired one
-        state.uiState.swipePanel = state.uiState.swipePanel && state.uiState.swipePanel === type ?
-          '' : type;
+        state.uiState.swipePanel = state.uiState.swipePanel && state.uiState.swipePanel === type
+          ? '' : type;
       },
       setLoginState(state, isLoggedin: boolean) {
         state.isLoggedin = isLoggedin;
-      }
-    }
+      },
+    },
   });
 
   // use defined or browser language
   const language = window.localStorage['evan-language'] || navigator.language.split('-')[0];
 
   // set correct moment language
-  const momentLanguages = [ 'en', 'de' ];
+  const momentLanguages = ['en', 'de'];
   moment.locale(momentLanguages.indexOf(language) === -1 ? 'en' : language);
 
   // set the i18n values and moment js
@@ -137,8 +136,8 @@ export async function initializeVue(options: EvanVueOptionsInterface) {
     el: options.container,
     router,
     store,
-    render: render => render(options.RootComponent),
-    mounted: function () {
+    render: (render) => render(options.RootComponent),
+    mounted() {
       // disable dev tools on prod
       if (!dappBrowser.utils.devMode) {
         delete this.$el.__vue__;
@@ -147,22 +146,22 @@ export async function initializeVue(options: EvanVueOptionsInterface) {
       // add an element id, so the dapp-loader can detect already loaded nested dapps
       this.$el.id = options.dappEnsOrContract;
       this.$el.className += ' evan-vue-dapp';
-      // apply the contract address as the id, so the dapp will not be loaded duplicated, when the
-      // contract address is opened under a dapp ens
+      /* apply the contract address as the id, so the dapp will not be loaded duplicated, when the
+         contract address is opened under a dapp ens */
       if (dappToLoad.contractAddress) {
         const contractAddressEl = document.createElement('div');
-        contractAddressEl.id = `${ dappToLoad.contractAddress }`;
+        contractAddressEl.id = `${dappToLoad.contractAddress}`;
         contractAddressEl.style.display = 'none';
         this.$el.appendChild(contractAddressEl);
       }
 
       // move toast container
       this.$el.appendChild(this.$toasted.container);
-    }
+    },
   });
 
-  // register event handlers, so multiple vue instance and removed dom elements will be destroyed
-  // correctly
+  /* register event handlers, so multiple vue instance and removed dom elements will be destroyed
+     correctly */
   registerEventHandlers(vue);
 
   return vue;
@@ -178,8 +177,8 @@ export async function initializeVue(options: EvanVueOptionsInterface) {
 export function registerComponents(Vue: any, components: Array<ComponentRegistrationInterface>) {
   // include all components
   components.forEach((def: ComponentRegistrationInterface) => {
-    // Vue.options.components[def.name] !== def.component
-    // do not overwrite the existing componet, only register the new component if it has changed
+    /* Vue.options.components[def.name] !== def.component
+       do not overwrite the existing componet, only register the new component if it has changed */
     if (!Vue.options.components[def.name]) {
       // register the component
       Vue.component(def.name, def.component);
@@ -195,7 +194,7 @@ export function registerComponents(Vue: any, components: Array<ComponentRegistra
  */
 export function registerEvanI18N(Vue: any, translations: any) {
   // add all i18n definitions
-  Object.keys(translations).forEach(key => Vue.i18n.add(key, translations[key]));
+  Object.keys(translations).forEach((key) => Vue.i18n.add(key, translations[key]));
 }
 
 /**
@@ -223,8 +222,8 @@ export function registerEventHandlers(vueInstance: any) {
       parent = parent.parentElement;
 
       if (!parent) {
-        // clear window.localStorage['evan-recovery-url'] when a new dapp was opened, so recovery
-        // will expire
+        /* clear window.localStorage['evan-recovery-url'] when a new dapp was opened, so recovery
+           will expire */
         delete window.localStorage['evan-recovery-url'];
 
         // clear listeners
@@ -241,4 +240,3 @@ export function registerEventHandlers(vueInstance: any) {
   // Start observing the target node for configured mutations
   elementObserver.observe(vueInstance.$el.parentElement, { childList: true, subtree: true });
 }
-

--- a/core/evancore.vue.libs/tsconfig.json
+++ b/core/evancore.vue.libs/tsconfig.json
@@ -1,12 +1,16 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": ["./src/**/*.ts", "./src/**/*.json"],
-  "exclude": ["dist"],
   "compilerOptions": {
+    "composite": true,
     "outDir": "dist",
     "rootDir": "./src",
-    "composite": true,
     "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "references": [{ "path": "../ui.libs" }]
+  "extends": "../../tsconfig.json",
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.json"
+  ],
+  "references": [
+    { "path": "../../core/ui.libs" }
+  ]
 }

--- a/core/ui.libs/dbcp.json
+++ b/core/ui.libs/dbcp.json
@@ -12,11 +12,11 @@
         "ui.libs.js",
         "ui.libs.css"
       ],
-      "origin": "QmdonjX44kDSwrVBP5FQvZkyFPQ5hZkjVSAMc2Hd4qY2tF",
+      "origin": "QmfVgUaEFUGsLs5cPLKaSN4gnNYRW81AS4WBGCs5QThSR3",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "",
@@ -50,7 +50,7 @@
       "1.7.1": "Qma2wvhCZeHbjdfw6R4CvECeuECoRW9SfuPG7Mn7Rm6b38",
       "1.7.2": "QmYLrqjVhPUKY2RvE8qSu5HeNTvm5A5u7GXHamQhuFNSAL",
       "1.7.3": "QmU7Zy3VodQDJ2XzLiY44aJurcZvAu6VjfXDe3z3CKfmhw",
-      "1.8.0": "QmUdDyQxzi8pkVboYNy2GGmu5BBExR72ZJWe849iK5Ef7V"
+      "1.8.0": "QmNktHbW8naQWrwsEVshUFLmfxvrANHnYTrFHymsw9XhbK"
     }
   }
 }

--- a/core/ui.libs/tsconfig.json
+++ b/core/ui.libs/tsconfig.json
@@ -1,10 +1,13 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": ["./src/**/*.ts"],
   "compilerOptions": {
+    "composite": true,
     "outDir": "dist",
     "rootDir": "./src",
-    "composite": true,
     "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
+  "extends": "../../tsconfig.json",
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.json"
+  ]
 }

--- a/core/ui.libs/webpack.config.js
+++ b/core/ui.libs/webpack.config.js
@@ -22,5 +22,5 @@ module.exports = require('../../scripts/dapp/webpack.config')(
   require('./dbcp.json').public.name,
   require('path').resolve(__dirname, './dist'),
   true,
-  false
+  false,
 );

--- a/dapps/addressbook.vue/dbcp.json
+++ b/dapps/addressbook.vue/dbcp.json
@@ -10,10 +10,10 @@
         "addressbook.vue.js",
         "addressbook.vue.css"
       ],
-      "origin": "QmUx4MokggCWR17eKpntkj6FeRWfvkiGWFHQU6ubuxuuhD",
+      "origin": "QmYaPSYpvCz6YdcAqKEiBzLkZyXjHLpFonZJqqDvQrC8mN",
       "primaryColor": "#52964b",
       "secondaryColor": "#e9f9e7",
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "Secure communication connections.",
@@ -47,7 +47,7 @@
       "3.0.0": "QmTgP2xvke2o5VEXCDho6bnkEi7er49iLYM8PotGbac8ce",
       "3.1.0": "QmYRB4J9cS31qqhT8xJ9AZ9bqQRPUrS6ZoCJxr9xoov1yo",
       "3.1.1": "QmV9DwRcg9vXtMS9eqHrS28PkTTtg3DY5RYEizGVwHch48",
-      "3.1.2": "QmWKsposWL8JtbrE2tAptQDMsZD1LNxPJGzGSGSgUh4rLC"
+      "3.1.2": "QmZL3t7tTQdfKxm2GG3LtEYYZKaggHnLQK5rfJdGYNEPNR"
     }
   }
 }

--- a/dapps/addressbook.vue/tsconfig.json
+++ b/dapps/addressbook.vue/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/dapps/addressbook.vue/tsconfig.json
+++ b/dapps/addressbook.vue/tsconfig.json
@@ -1,36 +1,13 @@
-// {
-//   "compilerOptions": {
-//     "baseUrl": "./src",
-//     "declaration": true,
-//     "experimentalDecorators": true,
-//     "lib": [
-//       "es2015",
-//       "dom"
-//     ],
-//     "module": "es2015",
-//     "moduleResolution": "node",
-//     "noImplicitAny": false,
-//     "outDir": "./built/",
-//     "skipLibCheck": true,
-//     "sourceMap": true,
-//     "strict": false,
-//     "strictFunctionTypes": false,
-//     "strictPropertyInitialization": false,
-//     "target": "es5"
-//   },
-//   "exclude": [
-//     "../../../node_modules/@evan.network"
-//   ],
-//   "include": [
-//     "./src/**/*",
-//     "../../scripts/dapp/vue-shim.d.ts"
-//   ]
-// }
-
-
 {
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "exclude": [
+    "../../../node_modules/@evan.network"
+  ],
   "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
+    "../../scripts/dapp/vue-shim.d.ts"
   ]
 }

--- a/dapps/assets/dbcp.json
+++ b/dapps/assets/dbcp.json
@@ -13,10 +13,10 @@
         "assets.js",
         "assets.css"
       ],
-      "origin": "QmUt3AybpEsg37F4DwWkAfJPjuvHtHrCNQu2n74gEA4riZ",
+      "origin": "QmPsjR32kUX2TC1iAu48DpssS6nPzmKxp1CWNR2yBXwVPr",
       "primaryColor": "#52964b",
       "secondaryColor": "#e9f9e7",
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "TODO",
@@ -37,6 +37,8 @@
       "evan"
     ],
     "version": "1.0.0",
-    "versions": {}
+    "versions": {
+      "1.0.0": "QmUvPvZX2sSJUDCDUc16sL2SbaHvLpC8vvr8h2FowP7VQd"
+    }
   }
 }

--- a/dapps/assets/src/index.ts
+++ b/dapps/assets/src/index.ts
@@ -32,8 +32,6 @@ export * from './components/registry';
 export { dispatcher } from './components/contacts/InviteDispatcher';
 export { translations };
 
-import { EvanComponent, EvanForm, DbcpFormComponentClass, ComponentRegistrationInterface ,DAppLoaderComponent  } from '@evan.network/ui-vue-core';
-
 System.map['@evan.network/assets'] = `assets.${getDomainName()}!dapp-content`;
 
 /**

--- a/dapps/assets/src/index.ts
+++ b/dapps/assets/src/index.ts
@@ -32,6 +32,8 @@ export * from './components/registry';
 export { dispatcher } from './components/contacts/InviteDispatcher';
 export { translations };
 
+import { EvanComponent, EvanForm, DbcpFormComponentClass, ComponentRegistrationInterface ,DAppLoaderComponent  } from '@evan.network/ui-vue-core';
+
 System.map['@evan.network/assets'] = `assets.${getDomainName()}!dapp-content`;
 
 /**

--- a/dapps/assets/tsconfig.json
+++ b/dapps/assets/tsconfig.json
@@ -1,13 +1,24 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
+  ],
+  "references": [
+    {
+      "path": "../../core/digital-twin-lib"
+    },
+    {
+      "path": "../../core/evancore.vue.libs"
+    },
+    {
+      "path": "../../core/ui.libs"
+    }
   ]
 }

--- a/dapps/assets/tsconfig.json
+++ b/dapps/assets/tsconfig.json
@@ -2,13 +2,12 @@
   "compilerOptions": {
     "outDir": "dist"
   },
+  "exclude": [
+    "../../../node_modules/@evan.network"
+  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*"
-  ],
-  "references": [
-    {
-      "path": "../../core/digital-twin-lib"
-    }
+    "./src/**/*",
+    "../../scripts/dapp/vue-shim.d.ts"
   ]
 }

--- a/dapps/assets/webpack.config.js
+++ b/dapps/assets/webpack.config.js
@@ -26,5 +26,5 @@ module.exports = require('../../scripts/dapp/webpack.config')(
   false,
   getExternals({
     '@evan.network/digital-twin-lib': '@evan.network/digital-twin-lib',
-  })
+  }),
 );

--- a/dapps/components.vue/dbcp.json
+++ b/dapps/components.vue/dbcp.json
@@ -9,10 +9,10 @@
       "files": [
         "components.vue.js"
       ],
-      "origin": "QmZN83xqFUHQLuQ6HdYFhGNf5df8pQX9twGJ8bwtSaK46o",
+      "origin": "QmWETdbxqmYiEUXqE9gueKwCXsampwtekMVsmYiX7iAUXc",
       "primaryColor": "#5170af",
       "secondaryColor": "#dfeaff",
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "Evan Vue Components",
@@ -36,7 +36,7 @@
     "version": "0.0.2",
     "versions": {
       "0.0.1": "QmWmcFy7R9kSdCr8k4D2zcKZz73seeGDk9KMq8abUT34oe",
-      "0.0.2": "QmbknZGUHsXtAnJQSyPzGrRFsVDsPgcx3cXe9vkUgi1Ps1"
+      "0.0.2": "QmbtwLFXbzatUw4gD8CWRWPv3GxQ3YXdiQFz4iHBdmjVfG"
     }
   }
 }

--- a/dapps/components.vue/tsconfig.json
+++ b/dapps/components.vue/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/dapps/components.vue/tsconfig.json
+++ b/dapps/components.vue/tsconfig.json
@@ -1,28 +1,11 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "resolveJsonModule": true,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/dapps/dashboard.vue/dbcp.json
+++ b/dapps/dashboard.vue/dbcp.json
@@ -9,11 +9,11 @@
       "files": [
         "dashboard.vue.js"
       ],
-      "origin": "QmeMTzVQucfhPbMyjKv8vLVrZ1VBe9Ci6Ce1MLcA1jvaWt",
+      "origin": "QmNtLYdD9FpeZUjJJKEs84o2bwcqHV9PwvBH9cooRnR3fA",
       "primaryColor": "#64c6c1",
       "secondaryColor": "#f9f9ff",
       "standalone": true,
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "Root app for displaying dapp favourites, mailbox.",
@@ -48,7 +48,7 @@
       "1.5.0": "QmXwbevvyD1fcPbWwVFUQi7sX2qUzC7CXRqUtZEzYpCw9X",
       "3.0.0": "QmXq76xeaLfXwkWTyo1KdvwzGAt5hEF2BPHVrcksXoRHpe",
       "3.1.0": "QmXCsXgkY4kNta3QgsLb3oC3gX4QeQwoxz1awM7w1U4kF3",
-      "3.2.0": "QmQCmaiVAmpEBANJTB81xAQzD7T3486QXfSnkLfv484VnH"
+      "3.2.0": "QmRcA8E5juAgm2AGbtLS6vkRkNE82YWPsgRa5wAsyVdZuk"
     }
   }
 }

--- a/dapps/dashboard.vue/tsconfig.json
+++ b/dapps/dashboard.vue/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/dapps/dashboard.vue/tsconfig.json
+++ b/dapps/dashboard.vue/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/dapps/digital-twin-detail/dbcp.json
+++ b/dapps/digital-twin-detail/dbcp.json
@@ -13,10 +13,10 @@
         "detail.digital-twin.js",
         "detail.digital-twin.css"
       ],
-      "origin": "QmfLRSd29bbfanBJzS3hmztEzGeTSvgYCdwSQ5R1gTk8vU",
+      "origin": "QmbHkoNWaCQaaQ8yPTDo2rLGC1deAduAUELPrJq31HcWKH",
       "primaryColor": "#52964b",
       "secondaryColor": "#e9f9e7",
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "TODO",
@@ -38,7 +38,7 @@
     ],
     "version": "1.0.0",
     "versions": {
-      "1.0.0": "QmUJpyqeyLRSQy8zRu2MgBy8BAoxpHjQFRwdpA78HzumCM"
+      "1.0.0": "QmSjnViLjpmBdGcDfCDJDfcWFrLocLRdfm7VFNjBbBEdvy"
     }
   }
 }

--- a/dapps/digital-twin-detail/src/components/container/DataSetForm.ts
+++ b/dapps/digital-twin-detail/src/components/container/DataSetForm.ts
@@ -139,15 +139,6 @@ export default class DataSetFormComponent extends mixins(EvanComponent) {
     switch (type) {
       case 'array': {
         control.uiSpecs.type = 'json';
-        // test for valid json
-        try {
-          JSON.parse(JSON.stringify(control.value));
-        } catch (ex) {
-          control.value = [];
-          logger.log(`[${this.$route.params.twin}][${this.$route.params.container}][${this.name}] `
-            + `Could not parse value of property ${name}`, 'error');
-        }
-
         break;
       }
       case 'boolean': {
@@ -162,14 +153,6 @@ export default class DataSetFormComponent extends mixins(EvanComponent) {
       }
       case 'object': {
         control.uiSpecs.type = 'json';
-        // test for valid json
-        try {
-          JSON.parse(JSON.stringify(control.value));
-        } catch (ex) {
-          control.value = { };
-          logger.log(`[${this.$route.params.twin}][${this.$route.params.container}][${this.name}] `
-            + `Could not parse value of property ${name}`, 'error');
-        }
         break;
       }
       case 'number': {

--- a/dapps/digital-twin-detail/src/components/container/List.vue
+++ b/dapps/digital-twin-detail/src/components/container/List.vue
@@ -40,6 +40,7 @@
           {{ '_evan.share' | translate }}
         </evan-button>
         <b-dropdown
+          :id="`dataset-list-${name}-dropdown`"
           class="p-0"
           variant="link"
           toggle-class="text-decoration-none"
@@ -58,6 +59,7 @@
             >{{ '_twin-detail.data.list.show-all' | translate }}</span>
           </b-dropdown-item>
           <b-dropdown-item
+            :id="`dataset-list-${name}-add`"
             @click="$refs.addListItem.showPanel()"
           >
             {{ '_twin-detail.data.list.add-list-item.title' | translate }}

--- a/dapps/digital-twin-detail/src/routes.ts
+++ b/dapps/digital-twin-detail/src/routes.ts
@@ -18,7 +18,7 @@
 */
 // import evan libs
 import { RouteConfig } from 'vue-router';
-import { UnderDevelopmentComponent } from 'core/evancore.vue.libs';
+import { UnderDevelopmentComponent } from '@evan.network/ui-vue-core';
 
 import ContainerComponent from './components/container/Container.vue';
 import DetailOverviewComponent from './components/overview/DetailOverview.vue';

--- a/dapps/digital-twin-detail/tsconfig.json
+++ b/dapps/digital-twin-detail/tsconfig.json
@@ -7,7 +7,7 @@
   },
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
+    "./src/**/*.ts",
     "./src/**/*.json"
   ],
   "references": [
@@ -16,6 +16,9 @@
     },
     {
       "path": "../../core/evancore.vue.libs"
+    },
+    {
+      "path": "../../core/ui.libs"
     }
   ]
 }

--- a/dapps/explorer.vue/dbcp.json
+++ b/dapps/explorer.vue/dbcp.json
@@ -9,11 +9,11 @@
       "files": [
         "explorer.vue.js"
       ],
-      "origin": "QmRaoPjeSSFTWhWmpY5pkYAdjJjVF9cUCKjEmtVBqisPhY",
+      "origin": "QmPQZz2PaXp6waa2HXWXwSpWusMA3c2JyaJ2pcXXZxcfSx",
       "primaryColor": "#4b9175",
       "secondaryColor": "#fff",
       "standalone": true,
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "Deep view into Contracts, DBCP and Profiles.",
@@ -36,7 +36,7 @@
     ],
     "version": "0.0.1",
     "versions": {
-      "0.0.1": "QmWLpk7umkcy7Buxw4BMrGnbNpBuMDetn2mHsYsrwSRPE9"
+      "0.0.1": "QmWmCAcsMN9dHkfVZCq4q63NWDdiG4PgnXASeRP2uP2mFZ"
     }
   }
 }

--- a/dapps/explorer.vue/tsconfig.json
+++ b/dapps/explorer.vue/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/dapps/explorer.vue/tsconfig.json
+++ b/dapps/explorer.vue/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/dapps/favorites.vue/dbcp.json
+++ b/dapps/favorites.vue/dbcp.json
@@ -9,10 +9,10 @@
       "files": [
         "favorites.vue.js"
       ],
-      "origin": "QmQC4eVAicJEckPajzAhXbQm8731hZDz1pbQPZYRR7V7ed",
+      "origin": "QmZwo4sPjgAg4f9XF91v6e7PHypixfPxYSGgDrUzF5rQ7D",
       "primaryColor": "#b66e74",
       "secondaryColor": "#edeada",
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "Handle your favourites.",
@@ -45,7 +45,7 @@
       "1.3.0": "QmQHkn1fsKFtga4KMMWBfAnbj9SXbdgNapNANzBke2a5xF",
       "1.5.0": "QmWi2uk4J8acE89pcFNBpfCr6eGErmCUnPBPGN4G61Syh4",
       "3.0.0": "QmNmduDDgWvEUXhkknVTWP4uLNsNJQZdig1saKorEnEhkS",
-      "3.1.0": "QmWepjbiK9zZUj1B8BVwnX3GhGUAxafrayYh34mfh4JKtq"
+      "3.1.0": "QmadpeEtRHqdzxfBNAFW7jbJjFbpjRnuU1ShVqMWDFKUqA"
     }
   }
 }

--- a/dapps/favorites.vue/tsconfig.json
+++ b/dapps/favorites.vue/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/dapps/favorites.vue/tsconfig.json
+++ b/dapps/favorites.vue/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/dapps/help.vue/dbcp.json
+++ b/dapps/help.vue/dbcp.json
@@ -9,10 +9,10 @@
       "files": [
         "help.vue.js"
       ],
-      "origin": "QmUYhpgmWuSVofUSaUY6BTdWi4j9MSs8BkdM8Y4YEEJctJ",
+      "origin": "QmfJP6bPmGz2EQ6xkcNFq95JXzod3ygzLutSQoQtfVpMMT",
       "primaryColor": "#5170af",
       "secondaryColor": "#dfeaff",
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "Evan introduction and help information.",
@@ -35,7 +35,7 @@
     ],
     "version": "0.0.1",
     "versions": {
-      "0.0.1": "QmbxT1buve31fFTVujrjbQdNJbBbTSnwfvZ9A5oVSxQBVK"
+      "0.0.1": "QmXbrHXTxe1aJL1cGn3yMGQhof83wfpScRSEa4kmRgdtEv"
     }
   }
 }

--- a/dapps/help.vue/tsconfig.json
+++ b/dapps/help.vue/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/dapps/help.vue/tsconfig.json
+++ b/dapps/help.vue/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/dapps/mailbox.vue/dbcp.json
+++ b/dapps/mailbox.vue/dbcp.json
@@ -9,10 +9,10 @@
       "files": [
         "mailbox.vue.js"
       ],
-      "origin": "QmRJC7Kk5VVtdaobLJu53NTEGLBM962ppU8FDZfGsrZquE",
+      "origin": "QmcS198jzMBzK6SdFpCLiRjGStrDkfUe2YgGW2jKE9Yzrq",
       "primaryColor": "#1862ac",
       "secondaryColor": "#f9f9ff",
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "Show new information Mails, Contact requests and latest notifications.",
@@ -48,7 +48,7 @@
       "3.1.0": "QmUMtmrXLVH29h5XaDsk6MGqaC5NGkUM8AdK2EcDCmyR46",
       "3.2.0": "QmchF3UYHdDsYX6wRhFu7cJLKVnRrWcaHwwnAo1kZhq8xW",
       "3.3.0": "QmY5nVCnCR49WQWHsr2Z8SQci6EkKKHJV18124qTKrdUpP",
-      "3.3.1": "QmSS2aNfEWHj2GunzLMZjzpbwKFxdkXFWjXjE7wL5YPppr"
+      "3.3.1": "QmdvZVZ6yChtL1wRnTkBiC4uWds4NidM8MwvtRkWecgAAc"
     }
   }
 }

--- a/dapps/mailbox.vue/tsconfig.json
+++ b/dapps/mailbox.vue/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/dapps/mailbox.vue/tsconfig.json
+++ b/dapps/mailbox.vue/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/dapps/onboarding.vue/dbcp.json
+++ b/dapps/onboarding.vue/dbcp.json
@@ -12,10 +12,10 @@
         "onboarding.vue.js",
         "onboarding.vue.css"
       ],
-      "origin": "QmNPxQSnb9Xj8GSKLUPFMonMSRa3AjXAFiYTYRnkd3HsFF",
+      "origin": "QmcWG3WMrubZyYoQ2c8JmN8CaM6QTi2hUbvubiQfPATAYs",
       "primaryColor": "#52964b",
       "secondaryColor": "#e9f9e7",
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "Setup your Evan Profile.",
@@ -50,7 +50,7 @@
       "3.1.0": "QmTVq3teuFda8e6Sf1andKuH8TiVYME4S5fbNSXE1mkoWw",
       "3.1.1": "QmfU4b8KtSa3DiCRLtyDQmdh4JK8Rk6RXbkpQ8QZyZoTVW",
       "3.2.0": "QmUxzPuPDcs8JQtHtw4CQp9L8Tcecf1WKfFCUZZJHY97eA",
-      "3.3.0": "QmRenapnT2rFi6kX8i8GgdAaJsN9GZF4fWsC48dccMsz2J"
+      "3.3.0": "QmUVLjhNHRq5Rc6UngPaL2PcyGL6ikBvF7pApgUcVfTofJ"
     }
   }
 }

--- a/dapps/onboarding.vue/tsconfig.json
+++ b/dapps/onboarding.vue/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/dapps/onboarding.vue/tsconfig.json
+++ b/dapps/onboarding.vue/tsconfig.json
@@ -1,25 +1,11 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "baseUrl": "./src",
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/dapps/profile.vue/dbcp.json
+++ b/dapps/profile.vue/dbcp.json
@@ -12,10 +12,10 @@
         "profile.vue.js",
         "profile.vue.css"
       ],
-      "origin": "QmYPgdJLRXJ1rzbR8uhSvHV76YHhTJYiD4Ja5ztQWAS5tm",
+      "origin": "QmSeBDvt3atFPKqDBns5LbaCTTBy1MoxmxJJV3sSGrzces",
       "primaryColor": "#ac7517",
       "secondaryColor": "#fff2dc",
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "Show the actual profile information.",
@@ -51,7 +51,7 @@
       "3.2.0": "QmSepNoYT6sd4NPk2qooQRGuDhHrxoM1C4bbsBjxRv8vUx",
       "3.3.0": "QmVwEhWqeomKL8nyHXfALAhcUrTmGeuhJpTgFMDJbBMtPw",
       "3.4.0": "QmP71KfTRWk8yoJVWgY7EYLTux7fsYE2XDCUS94tG12UTH",
-      "3.5.1": "QmZ2EyMYcxynh7qzQHUxrLv3HFSpcPbqAsZ776cRzFMVFt"
+      "3.5.1": "QmXRam3oXQeTJswpwVjyxBpWKWiYTTojrDd5NxTqsBaiYB"
     }
   }
 }

--- a/dapps/profile.vue/tsconfig.json
+++ b/dapps/profile.vue/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/dapps/profile.vue/tsconfig.json
+++ b/dapps/profile.vue/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/evan-libs/bcc/dbcp.json
+++ b/evan-libs/bcc/dbcp.json
@@ -9,8 +9,8 @@
       "files": [
         "bcc.js"
       ],
-      "origin": "QmZJej512oNfZTRxM61vnav13kqMhwVeMiMiHA1XzzFQNL",
-      "type": "library"
+      "origin": "QmXcdE2ZmemJgU7EyXqFf89nGmTdrRd34cEkMsucRZZv9m",
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "Browserified api-blockchain-core to interact with evan.network blockchain.",
@@ -24,7 +24,7 @@
       "dapp",
       "library"
     ],
-    "version": "2.15.0",
+    "version": "2.17.0",
     "versions": {
       "0.1.0": "QmTsY7ASbvxATLnEemHZQ8oQha64ujYe9VXbDCouDk7Xtp",
       "0.9.0": "Qmbw3yX82TVN9WhsRyeaRpd89M9XXL1pds9GgqJL29ohar",
@@ -59,7 +59,8 @@
       "2.13.0": "QmUe28YGGJk4rnqiPwMJESY7q4PCG5QWW7pfJxsJxNRHQx",
       "2.14.0": "QmdUzHAuzaNuNDvrGbLADCnGgHz82iDbVAVwnD2yyvDuum",
       "2.14.1": "QmcMa3rPELxxi3cW8GtBHN15vjEy9QAxaDpvA4ikpqq88w",
-      "2.15.0": "QmYYjoposvPzQGQDbWseUqVv1dx4K3WrrrLS4HpTCAPWPF"
+      "2.15.0": "QmYYjoposvPzQGQDbWseUqVv1dx4K3WrrrLS4HpTCAPWPF",
+      "2.17.0": "QmRv9jJZWd4TKdUN2mXFMxxZnfe3EsCHKx65KgBUvWbEn9"
     }
   }
 }

--- a/evan-libs/bcc/package.json
+++ b/evan-libs/bcc/package.json
@@ -15,5 +15,5 @@
     "build": "node ./gulp/buildBcc.js && gulp --gulpfile ../../scripts/dapp/browserify.js browserify --dapp $(pwd)"
   },
   "typings": "dist/index.d.ts",
-  "version": "2.15.0"
+  "version": "2.17.0"
 }

--- a/evan-libs/smartcontracts/dbcp.json
+++ b/evan-libs/smartcontracts/dbcp.json
@@ -6,8 +6,8 @@
       "files": [
         "compiled.js"
       ],
-      "origin": "QmSa3s1Z5mqyjcoQJ7mYj3rKqYrTV4vwfmhYMAdvGTPigJ",
-      "type": "library"
+      "origin": "QmbkWvxbedgkcosM18XbUAqeLocsbVtwnB2B6wGJ7wSqJi",
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "evan.network core smart contracts",
@@ -17,7 +17,7 @@
       "contractus",
       "library"
     ],
-    "version": "2.7.0",
+    "version": "2.9.0",
     "versions": {
       "0.1.0": "QmQ576qcoH4GXKRTYq3xqYJR62Lhf5665ySTj6YyENMZPJ",
       "0.9.0": "QmNfBLnAM4DctyNxg7CbE4mtYdmQfTN9bVGx8x12nMvjUD",
@@ -44,7 +44,8 @@
       "2.5.0": "QmYN11YjQ5c8axJQ8fjPcbbjVzi1Dsv7JLsy2wdoRe7SeN",
       "2.6.0": "QmP4vHq44S3EF3kkMWDSYM2jDE8GG9X4pUpDzsdwZJ7xVe",
       "2.6.1": "QmfPFVjjiWk48Pw125w1yRThaE5rr4XjfDnjFiZLzxqdhH",
-      "2.7.0": "QmbesJHebrbEarqwzgfEKm566MMJvXE6VfcyEJBdaAXaa2"
+      "2.7.0": "QmbesJHebrbEarqwzgfEKm566MMJvXE6VfcyEJBdaAXaa2",
+      "2.9.0": "QmWrGpzi5aAT5rGDt3tqkfWyrvL2esqWp5TMizmv678b3t"
     }
   }
 }

--- a/evan-libs/smartcontracts/package.json
+++ b/evan-libs/smartcontracts/package.json
@@ -15,5 +15,5 @@
     "build": "node gulp/buildContracts.js && gulp --gulpfile ../../scripts/dapp/browserify.js browserify --dapp $(pwd)"
   },
   "typings": "dist/index.d.ts",
-  "version": "2.8.0"
+  "version": "2.9.0"
 }

--- a/libs/ajv-i18n/dbcp.json
+++ b/libs/ajv-i18n/dbcp.json
@@ -7,7 +7,7 @@
       "files": [
         "i18n.ajv.js"
       ],
-      "origin": "QmUPv5dpsTi9auLVtweb3BB95FjiPzfPhre7my7Z39H23a",
+      "origin": "QmdLmScDuwuYWyVtqdJAz2NQXZSRcDHgmnFRes1rTXKk16",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -32,7 +32,7 @@
     ],
     "version": "3.5.0",
     "versions": {
-      "3.5.0": "QmUMZPqRoXFJQGapkbEymgjHwgMbdB6YMDfLUcz65awd42"
+      "3.5.0": "QmYMkwBhwGQqYQAEFoTtyvmxBBajEoRNEWNMFZXmjtzHeS"
     }
   }
 }

--- a/libs/ajv-i18n/tsconfig.json
+++ b/libs/ajv-i18n/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/libs/ajv-i18n/tsconfig.json
+++ b/libs/ajv-i18n/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/axios.vue.libs/dbcp.json
+++ b/libs/axios.vue.libs/dbcp.json
@@ -9,7 +9,7 @@
       "files": [
         "axios.vue.libs.js"
       ],
-      "origin": "QmTvJHwSnN8dnqBrPnPY37Zy4WybkNaGQRGukuEGpCjJgT",
+      "origin": "QmXWZVmZ4sdAMqGnjVud9Wk3CkWDHx5LDAFCZzrnGg7rg5",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -34,7 +34,7 @@
     ],
     "version": "0.18.0",
     "versions": {
-      "0.18.0": "QmTybWhdaosfC7vzd5GuWneeEfHMZuWXhDnymSVCVDSxaz"
+      "0.18.0": "QmSNqL7vCxYYdH94Dk9hKbf8szMeMV9reMq1QsPKUTRfB5"
     }
   }
 }

--- a/libs/axios.vue.libs/tsconfig.json
+++ b/libs/axios.vue.libs/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/libs/axios.vue.libs/tsconfig.json
+++ b/libs/axios.vue.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/boostrap.vue.libs/dbcp.json
+++ b/libs/boostrap.vue.libs/dbcp.json
@@ -9,7 +9,7 @@
       "files": [
         "bootstrap.vue.libs.js"
       ],
-      "origin": "QmT7dp7EsfupwBxw7FypsEAqNjkr14BNXVLhDFrMo92aWf",
+      "origin": "QmU9DaHCuMEXe8DHd1UoCVD5tvuKvRJnGQKwEtg2jkZbHE",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -34,7 +34,7 @@
     ],
     "version": "2.1.0",
     "versions": {
-      "2.1.0": "QmebiGS24QYtDZWtvcaUEStQPP6K7LEbhV2QvTbgWNrsmK"
+      "2.1.0": "QmXyNGT6W2EFmDVoC195nz6heFYknwhRrUqkjCCd5cjoAB"
     }
   }
 }

--- a/libs/boostrap.vue.libs/tsconfig.json
+++ b/libs/boostrap.vue.libs/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/libs/boostrap.vue.libs/tsconfig.json
+++ b/libs/boostrap.vue.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/countries.libs/dbcp.json
+++ b/libs/countries.libs/dbcp.json
@@ -7,11 +7,11 @@
       "files": [
         "countries.libs.js"
       ],
-      "origin": "QmYfHcZihBXPQuPtEWJaE5p39XmyHqGss3n5bCmhrnyQ6T",
+      "origin": "QmVFRTwmbuERpNEEjBmfCrUnopynpV5ii5Z47w6aMdDG1s",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
-      "type": "dapp"
+      "type": "cached-dapp"
     },
     "dbcpVersion": 2,
     "description": "",
@@ -33,7 +33,7 @@
     "version": "1.1.0",
     "versions": {
       "1.0.0": "QmXmzcmMC536XBtKcLYYHib7aY6GCsXgqdc6NTt84MVmjn",
-      "1.1.0": "QmRnKGznQSXjh3X9YdvZYVX8q9twKjaCyCmiV34DWgYhzw"
+      "1.1.0": "Qmd42pR1bzp2JFu6Zk9aPfgJDaZTR6mPtSv2Qm5Wz3D4PL"
     }
   }
 }

--- a/libs/countries.libs/tsconfig.json
+++ b/libs/countries.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "composite": true,
-    "outDir": "dist",
-    "rootDir": "./src",
-    "tsBuildInfoFile": "./dist/tsbuildinfo"
+    "outDir": "dist"
   },
+  "exclude": [
+    "../../../node_modules/@evan.network"
+  ],
   "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
-    "./src/**/*.json"
+    "../../scripts/dapp/vue-shim.d.ts"
   ]
 }

--- a/libs/countries.libs/tsconfig.json
+++ b/libs/countries.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/d3.libs/dbcp.json
+++ b/libs/d3.libs/dbcp.json
@@ -7,7 +7,7 @@
       "files": [
         "d3.libs.js"
       ],
-      "origin": "QmPpQfe4ZRQvBJcJNWo9We6zAKg7GAxPPZ671RA3Kh8Coy",
+      "origin": "QmbXE2Hk433CDs7pVJkRthCuKKvxzKZpfiDQiK56VDuQuE",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -32,7 +32,7 @@
     ],
     "version": "5.7.0",
     "versions": {
-      "5.7.0": "QmQYK8QBTQqdQJpcTJFTtdJqPdzqJnsBMSdehrJCFUqZ27"
+      "5.7.0": "QmZmN5sQ9m1NuWzKkPXyuTr3dHUwwcB33CwED2y1DWKCz8"
     }
   }
 }

--- a/libs/d3.libs/tsconfig.json
+++ b/libs/d3.libs/tsconfig.json
@@ -1,24 +1,13 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*"
+    "./src/**/*",
+    "../../scripts/dapp/vue-shim.d.ts"
   ]
 }

--- a/libs/d3.libs/tsconfig.json
+++ b/libs/d3.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/dexie.libs/dbcp.json
+++ b/libs/dexie.libs/dbcp.json
@@ -7,7 +7,7 @@
       "files": [
         "dexie.libs.js"
       ],
-      "origin": "QmdqXcMocgYWK8Hfrpq1SRT2TKNSX1fofndueqcmF3w5mu",
+      "origin": "QmRMHA2QDexgD8SYcw8HianiC26fzeq7cMsVJoHTg4EL5T",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -32,7 +32,7 @@
     ],
     "version": "2.0.4",
     "versions": {
-      "2.0.4": "QmdqXcMocgYWK8Hfrpq1SRT2TKNSX1fofndueqcmF3w5mu"
+      "2.0.4": "QmcqjNcXrvnJD6uCRwMpPfWFbWnFJuxzaC57nt4hDpDaxD"
     }
   }
 }

--- a/libs/dexie.libs/tsconfig.json
+++ b/libs/dexie.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/dexie.libs/tsconfig.json
+++ b/libs/dexie.libs/tsconfig.json
@@ -1,25 +1,13 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "paths": {},
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*"
+    "./src/**/*",
+    "../../scripts/dapp/vue-shim.d.ts"
   ]
 }

--- a/libs/fontawesome.libs/dbcp.json
+++ b/libs/fontawesome.libs/dbcp.json
@@ -8,7 +8,7 @@
         "fontawesome.libs.js",
         "fontawesome.libs.css"
       ],
-      "origin": "QmTVoaRewYH98oXb4vvEPnWr3MBUPP9E2gzPJYWFkfZya1",
+      "origin": "QmQSqV1oHk7N26LGMeCFRbx1uT4USgLeZoFj9kncVtqFAu",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -33,7 +33,7 @@
     ],
     "version": "5.7.2",
     "versions": {
-      "5.7.2": "QmaTgmyxdQ88NaP7htJx94QzE4qisYFstQrnrJ1RcJRPg2"
+      "5.7.2": "QmVus6a8Tvt3kSfM3earSVACjW8S34S5H5SZw6NvRbr6TE"
     }
   }
 }

--- a/libs/fontawesome.libs/tsconfig.json
+++ b/libs/fontawesome.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/fontawesome.libs/tsconfig.json
+++ b/libs/fontawesome.libs/tsconfig.json
@@ -1,25 +1,13 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "paths": {},
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*"
+    "./src/**/*",
+    "../../scripts/dapp/vue-shim.d.ts"
   ]
 }

--- a/libs/i18n.vuex.libs/dbcp.json
+++ b/libs/i18n.vuex.libs/dbcp.json
@@ -10,7 +10,7 @@
       "files": [
         "i18n.vuex.libs.js"
       ],
-      "origin": "QmcsAuC9k7ouZPj4EHYGYxkXVdAPumxyyLjN3Zjo8wcnyz",
+      "origin": "QmcVXfhqwCNjp7ZmEZdmkGsR3ZLn628Gsg4E7y5mmU7FnR",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -35,7 +35,7 @@
     ],
     "version": "1.11.0",
     "versions": {
-      "1.11.0": "Qmd8LMBfg88S2sq48aZr9bimbMcPzt5MK45ExJfBoYYjyc"
+      "1.11.0": "QmSA7E6gQYCjzkPiiKqiVx8KjW9wykYKQdg1dgvZ1CteD7"
     }
   }
 }

--- a/libs/i18n.vuex.libs/tsconfig.json
+++ b/libs/i18n.vuex.libs/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/libs/i18n.vuex.libs/tsconfig.json
+++ b/libs/i18n.vuex.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/leaflet.vue.libs/dbcp.json
+++ b/libs/leaflet.vue.libs/dbcp.json
@@ -10,7 +10,7 @@
         "leaflet.vue.libs.js",
         "leaflet.vue.libs.css"
       ],
-      "origin": "Qmd5XddFzM7AAfd2AFrzircgEYTGSmCkQcEim4NLcPyvrY",
+      "origin": "QmSswAjyk3aToGaoCiKiu3yWmsZvQv9dAKgPea49VzfzN9",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -35,7 +35,7 @@
     ],
     "version": "3.1.0",
     "versions": {
-      "3.1.0": "QmascnPRu5v6t5nXcCzqXWWKwTp1EvBXqyEPyhFJPJ7SdN"
+      "3.1.0": "QmRpNhG1uiTtfCdgqmh33XmeqYaWCAMPNKzNgrqwVUmWhd"
     }
   }
 }

--- a/libs/leaflet.vue.libs/tsconfig.json
+++ b/libs/leaflet.vue.libs/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/libs/leaflet.vue.libs/tsconfig.json
+++ b/libs/leaflet.vue.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/lodash.libs/dbcp.json
+++ b/libs/lodash.libs/dbcp.json
@@ -7,7 +7,7 @@
       "files": [
         "lodash.libs.js"
       ],
-      "origin": "QmV23JwLoYGPbkdhQH6rYRBe3CZ6jpyosmCrcd7Fmzi3zs",
+      "origin": "QmamXMjGqsvrqUvJo2mFTKkm6Z44PWMe2as2zwufNMxnRQ",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -33,7 +33,7 @@
     "version": "4.17.15",
     "versions": {
       "4.17.11": "QmV9PhHPfKaUxbnnkoBhsK1m7TKFes7M1U3GymAH6omwY2",
-      "4.17.15": "Qmc5ja4RH8Wv8gEMRyicDZ5b7SZ1jc3HFr5jDPVXFwY5nS"
+      "4.17.15": "QmS5f4GCQuiGPpkkqAN9DNiMYmNLPgdSiTgVRvmkSs5iss"
     }
   }
 }

--- a/libs/lodash.libs/tsconfig.json
+++ b/libs/lodash.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/lodash.libs/tsconfig.json
+++ b/libs/lodash.libs/tsconfig.json
@@ -1,25 +1,13 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "paths": {},
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*"
+    "./src/**/*",
+    "../../scripts/dapp/vue-shim.d.ts"
   ]
 }

--- a/libs/materialicons.libs/dbcp.json
+++ b/libs/materialicons.libs/dbcp.json
@@ -8,7 +8,7 @@
         "materialicons.libs.css",
         "materialicons.libs.js"
       ],
-      "origin": "QmQh2Ljdu3XenXbqQWjziQ8YCDJkF5FdubBYGK9ZXtVZjq",
+      "origin": "QmY75UyjXKsFL3SfY34vFCTmpNyzKbTwHHRe76x4pUff6j",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -35,7 +35,7 @@
     "versions": {
       "1.8.36": "QmdocVBKgt9zDeNU2CBP6m9gR8vWtPH9ehNuQkEEUeW8AN",
       "4.4.0": "QmWadpx9RE982ZosokU3KVmEZWc7DyCmGNSh97SxbNMnwc",
-      "4.5.0": "QmVu48XrGBtb6asdosYTb5ZgMxnK3DgHC9pc1sSJgGokiu"
+      "4.5.0": "QmWhZFexWBdgEmHthi6B21D4rDtyx9QS8NrPoFAdBwBhg3"
     }
   }
 }

--- a/libs/materialicons.libs/tsconfig.json
+++ b/libs/materialicons.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/materialicons.libs/tsconfig.json
+++ b/libs/materialicons.libs/tsconfig.json
@@ -1,25 +1,13 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "paths": {},
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*"
+    "./src/**/*",
+    "../../scripts/dapp/vue-shim.d.ts"
   ]
 }

--- a/libs/moment.libs/dbcp.json
+++ b/libs/moment.libs/dbcp.json
@@ -7,7 +7,7 @@
       "files": [
         "moment.libs.js"
       ],
-      "origin": "QmU2BvqthbiEU1c5w1GepWfraDVp3JHhn2SWC8avoYSDRY",
+      "origin": "QmVD6zqQLZQsp3xsM6xvmZ84kVfWhepZ84cvsKMXfv5gW7",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -32,7 +32,7 @@
     ],
     "version": "2.24.0",
     "versions": {
-      "2.24.0": "QmU2BvqthbiEU1c5w1GepWfraDVp3JHhn2SWC8avoYSDRY"
+      "2.24.0": "QmVDXPtX8xRpHHs2JdTArGyDveeXMB3pquA4F7rzy2Mz3q"
     }
   }
 }

--- a/libs/moment.libs/tsconfig.json
+++ b/libs/moment.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/moment.libs/tsconfig.json
+++ b/libs/moment.libs/tsconfig.json
@@ -1,25 +1,13 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "paths": {},
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*"
+    "./src/**/*",
+    "../../scripts/dapp/vue-shim.d.ts"
   ]
 }

--- a/libs/moment.vue.libs/dbcp.json
+++ b/libs/moment.vue.libs/dbcp.json
@@ -10,7 +10,7 @@
       "files": [
         "moment.vue.libs.js"
       ],
-      "origin": "QmPfjHPHCBdSGzLp6c4X5UHD2zTXjthMrpv5EzbhWq31fk",
+      "origin": "QmbyKnFQ7mLrioEH7vJFxHsikNXcWC2cLDcmP7WuikX2T9",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -35,7 +35,7 @@
     ],
     "version": "4.0.0",
     "versions": {
-      "4.0.0": "QmXzzUp88As3BKdpJWXd6ZbHPoDW2i4cbWcV6LQSsRbxhT"
+      "4.0.0": "QmXHkymidMQLgo8FRwdyf8uGPHHbrUjBGdX6K1MWdYMPd7"
     }
   }
 }

--- a/libs/moment.vue.libs/tsconfig.json
+++ b/libs/moment.vue.libs/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/libs/moment.vue.libs/tsconfig.json
+++ b/libs/moment.vue.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/moment.vue.libs/webpack.config.js
+++ b/libs/moment.vue.libs/webpack.config.js
@@ -26,5 +26,6 @@ module.exports = require('../../scripts/dapp/webpack.config')(
   {
     '@evan.network/ui-dapp-browser': '@evan.network/ui-dapp-browser',
     vue: 'vue',
+    moment: 'moment',
   },
 );

--- a/libs/qrcodejs.libs/dbcp.json
+++ b/libs/qrcodejs.libs/dbcp.json
@@ -7,7 +7,7 @@
       "files": [
         "qrcodejs.libs.js"
       ],
-      "origin": "QmcEb8GezZ1iCugJGVLpT7uCviaJVt6YYZEz2k3NQWJKb1",
+      "origin": "QmV5ZRSyHVXkzmkBrGkc8nmaZTLEPoybytzhRvCvfTjYqA",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -32,7 +32,7 @@
     ],
     "version": "1.0.0",
     "versions": {
-      "1.0.0": "QmPP72FGMTmnfWahJTEqbnGjmjZgSPUkSXTisGanWrJJ8o"
+      "1.0.0": "QmckhuBVeQCUUpcgDjPTTwXVWYHiRdpMt57psU1znwnA9P"
     }
   }
 }

--- a/libs/qrcodejs.libs/tsconfig.json
+++ b/libs/qrcodejs.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/qrcodejs.libs/tsconfig.json
+++ b/libs/qrcodejs.libs/tsconfig.json
@@ -1,25 +1,13 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "paths": {},
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*"
+    "./src/**/*",
+    "../../scripts/dapp/vue-shim.d.ts"
   ]
 }

--- a/libs/recaptcha.vue.libs/dbcp.json
+++ b/libs/recaptcha.vue.libs/dbcp.json
@@ -9,7 +9,7 @@
       "files": [
         "recaptcha.vue.libs.js"
       ],
-      "origin": "QmSE2Tb9CQdGv9HyKsoqi4eSiNG4sjmAQ3oGtSTNXTxcan",
+      "origin": "QmYyoojUcVKh1fv58iswYLPDCiXdCQ26ut1k1mVL23VnVh",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -34,7 +34,7 @@
     ],
     "version": "1.1.1",
     "versions": {
-      "1.1.1": "Qme8uxSGYAegHDgHhRHV6pfrnGwdPwusVsKAFdGh6G9Ukn"
+      "1.1.1": "QmfTT6GBzDKfvGXJMQ6A4AAr4RFp8u48kLLdNhTays4khR"
     }
   }
 }

--- a/libs/recaptcha.vue.libs/tsconfig.json
+++ b/libs/recaptcha.vue.libs/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/libs/recaptcha.vue.libs/tsconfig.json
+++ b/libs/recaptcha.vue.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/router.vue.libs/dbcp.json
+++ b/libs/router.vue.libs/dbcp.json
@@ -9,7 +9,7 @@
       "files": [
         "router.vue.libs.js"
       ],
-      "origin": "QmQkChJE77pV43E6eDqdynzdq5LKHhPdwwUs45RH7is3Ue",
+      "origin": "QmT5FToJqdRZaCLcfPGVbsuPrjb1ggjJNdPwJRBHCSbpSh",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -34,7 +34,7 @@
     ],
     "version": "2.5.2",
     "versions": {
-      "2.5.2": "QmYiYmqarQVFNFkTQS8TwyXRnvAcEM48CKXTuzBfANSQKF"
+      "2.5.2": "QmUcqLobqPpgu7VbJ4P2YggfV8zRPu9L8MnVJZuaG6HjCh"
     }
   }
 }

--- a/libs/router.vue.libs/tsconfig.json
+++ b/libs/router.vue.libs/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/libs/router.vue.libs/tsconfig.json
+++ b/libs/router.vue.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/select.vue.libs/dbcp.json
+++ b/libs/select.vue.libs/dbcp.json
@@ -10,7 +10,7 @@
         "select.vue.libs.js",
         "select.vue.libs.css"
       ],
-      "origin": "Qma7CsGQzd5dFqkqaSqeBieD5QRYuvEtqSGgyjeAF7jWTt",
+      "origin": "QmVF2JPADL17dCce4Dc5YKJ4n9wLNhMqvEsQBHffnSqGkJ",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -35,7 +35,7 @@
     ],
     "version": "3.2.0",
     "versions": {
-      "3.2.0": "QmTJP7Koxio1D4SbG8q4CsuK14t2XX6KrvwFNv8DcyJzaG"
+      "3.2.0": "QmXfUwUjtW1adfpXu31jM64sBiFNaL1BUniQw7mL34jc2E"
     }
   }
 }

--- a/libs/select.vue.libs/tsconfig.json
+++ b/libs/select.vue.libs/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/libs/select.vue.libs/tsconfig.json
+++ b/libs/select.vue.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/themify.libs/dbcp.json
+++ b/libs/themify.libs/dbcp.json
@@ -7,7 +7,7 @@
       "files": [
         "themify.libs.css"
       ],
-      "origin": "QmdzawiPJSmJCLWyhk7sL6fUna1T3HkfzSLe9GFZoAKNob",
+      "origin": "Qmc9VU11tdZzFVWZSqdNoczGMS3i4BbSFedfuxwuHxiRMQ",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -32,7 +32,7 @@
     ],
     "version": "1.0.0",
     "versions": {
-      "1.0.0": "QmNwWiRWnTqgc8dirTfLmXeo4ECbCNE8q5kbhrrV65Gc5U"
+      "1.0.0": "Qmd3H3AjuyK6AJp2CuwqdwevmsGdKhWyeyzJi8Pw7hRCfG"
     }
   }
 }

--- a/libs/themify.libs/tsconfig.json
+++ b/libs/themify.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/themify.libs/tsconfig.json
+++ b/libs/themify.libs/tsconfig.json
@@ -1,25 +1,13 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "paths": {},
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*"
+    "./src/**/*",
+    "../../scripts/dapp/vue-shim.d.ts"
   ]
 }

--- a/libs/toasted.vue.libs/dbcp.json
+++ b/libs/toasted.vue.libs/dbcp.json
@@ -9,7 +9,7 @@
       "files": [
         "toasted.vue.libs.js"
       ],
-      "origin": "Qmb6yk8WHxXWXvhxtFAKpWKh7xghAoUYEHJ7PjfdqHJMUh",
+      "origin": "QmagViEcG3BnFis1bVBCr4EgP14HPZpX1pGBuzcdcfpz8R",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -34,7 +34,7 @@
     ],
     "version": "1.1.27",
     "versions": {
-      "1.1.27": "Qmb6yk8WHxXWXvhxtFAKpWKh7xghAoUYEHJ7PjfdqHJMUh"
+      "1.1.27": "QmYboN2pdujHuqY6PkrSQcjV9jp4DReNeHHJJ1Vz8BnmbZ"
     }
   }
 }

--- a/libs/toasted.vue.libs/tsconfig.json
+++ b/libs/toasted.vue.libs/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/libs/toasted.vue.libs/tsconfig.json
+++ b/libs/toasted.vue.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/vue.libs/dbcp.json
+++ b/libs/vue.libs/dbcp.json
@@ -7,7 +7,7 @@
       "files": [
         "vue.libs.js"
       ],
-      "origin": "QmUPv5dpsTi9auLVtweb3BB95FjiPzfPhre7my7Z39H23a",
+      "origin": "QmVkvtLL9FPuEKMo8r4CmjXqK6uCMwTEMSnRrhRd7xV94G",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -32,7 +32,7 @@
     ],
     "version": "2.5.2",
     "versions": {
-      "2.5.2": "QmUMZPqRoXFJQGapkbEymgjHwgMbdB6YMDfLUcz65awd42"
+      "2.5.2": "QmbQTphQ2axHALvZtSpX7v2dcnoH6APuhZXmp1K2HazYk8"
     }
   }
 }

--- a/libs/vue.libs/tsconfig.json
+++ b/libs/vue.libs/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/libs/vue.libs/tsconfig.json
+++ b/libs/vue.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/libs/vuex.libs/dbcp.json
+++ b/libs/vuex.libs/dbcp.json
@@ -9,7 +9,7 @@
       "files": [
         "vuex.libs.js"
       ],
-      "origin": "QmXCzHU1dAf5FZiEc4He8JEPbU1CGyeSL5k7orEujEvPcb",
+      "origin": "QmQbt9QcVyim8dch7bcpQ1UFKypzZEZY8SdRCBwdyW3dEH",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -34,7 +34,7 @@
     ],
     "version": "3.1.0",
     "versions": {
-      "3.1.0": "QmXwQGTSvhDinspZDR6ThXYs3szfFx2hjiRMLeT7wgNGsj"
+      "3.1.0": "QmPUUcmy4AcDZ3U4w8M5LTfKiimfd3aGyKq77hVVg4BA6S"
     }
   }
 }

--- a/libs/vuex.libs/tsconfig.json
+++ b/libs/vuex.libs/tsconfig.json
@@ -1,26 +1,11 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
-    "declaration": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "outDir": "./built/",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": false,
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
-    "target": "es5"
+    "outDir": "dist"
   },
   "exclude": [
     "../../../node_modules/@evan.network"
   ],
+  "extends": "../../tsconfig.json",
   "include": [
     "./src/**/*",
     "../../scripts/dapp/vue-shim.d.ts"

--- a/libs/vuex.libs/tsconfig.json
+++ b/libs/vuex.libs/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsbuildinfo"
   },
-  "exclude": [
-    "../../../node_modules/@evan.network"
-  ],
   "extends": "../../tsconfig.json",
   "include": [
-    "./src/**/*",
-    "../../scripts/dapp/vue-shim.d.ts"
+    "./src/**/*.ts",
+    "./src/**/*.json"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {

--- a/scripts/dapp/browserify.js
+++ b/scripts/dapp/browserify.js
@@ -95,16 +95,18 @@ gulp.task('browserify', async function(callback) {
           // underscore gets broken when we try to parse it
           /underscore/,
 
+
           // remove core-js and babel runtime,
           // https://github.com/babel/babel/issues/8731#issuecomment-426522500
-          /[\/\\]core-js/,
-          /@babel[\/\\]runtime/,
+         // /[\/\\]core-js/,
+         // /@babel[\/\\]runtime/,
         ],
         presets: [
-          '@babel/env'
+          //'@babel/env',
+          ["@babel/preset-env", { targets: { browsers: "ios >= 11" } }]
         ],
         plugins: [
-          '@babel/plugin-transform-runtime',
+          //'@babel/plugin-transform-runtime',
           // include lodash plugin to pull all lodash functions and imports together and down size the
           // bundle
           'lodash'

--- a/scripts/dapp/webpack.config.js
+++ b/scripts/dapp/webpack.config.js
@@ -42,16 +42,15 @@ module.exports = function getWebpackConfig(
   name,
   dist,
   transpileOnly = false,
-  prodMode = process.env.NODE_ENV === 'production',
+  forceProdMode = false,
   externals = getExternals(),
 ) {
-  // enable prodMode, when node_env was set
-
+  const prodMode = forceProdMode || process.env.NODE_ENV === 'production';
   const webpackConfig = {
     entry: './src/index.ts',
     externals,
     devtool: '#eval-source-map',
-    mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
+    mode: prodMode ? 'production' : 'development',
     output: {
       path: dist,
       publicPath: '/dist/',
@@ -154,7 +153,7 @@ module.exports = function getWebpackConfig(
       new UglifyJsPlugin({
         exclude: /(node_modules)/,
         parallel: true,
-        sourceMap: false,
+        sourceMap: true,
         test: /\.js($|\?)/i,
         uglifyOptions: {
           output: {

--- a/scripts/dapp/webpack.externals.js
+++ b/scripts/dapp/webpack.externals.js
@@ -41,6 +41,7 @@ module.exports = function getCustomExcludes(customExcludes) {
     axios: 'axios',
     dexie: 'dexie',
     lodash: 'lodash',
+    moment: 'moment',
     qrcodejs: 'qrcodejs',
     vue: 'vue',
     vuex: 'vuex',

--- a/tests-e2e/features/assets/digital-twins/digital-twin-detail.feature
+++ b/tests-e2e/features/assets/digital-twins/digital-twin-detail.feature
@@ -1,4 +1,4 @@
-Feature: Digital Twin Detail
+Feature: Digital Twin - Detail
 
   Background:
     Given I log in to evan.network using vue

--- a/tests-e2e/features/assets/digital-twins/digital-twins-create.feature
+++ b/tests-e2e/features/assets/digital-twins/digital-twins-create.feature
@@ -1,4 +1,4 @@
-Feature: Digital Twins
+Feature: Digital Twin - Creation
   Test different scenarios using predefined templates, upload of correct template and a template with missing properties.
   Checks also if empty description field is filled with the translated value from template.
 

--- a/tests-e2e/features/assets/digital-twins/digital-twins-data-set.feature
+++ b/tests-e2e/features/assets/digital-twins/digital-twins-data-set.feature
@@ -1,20 +1,22 @@
-Feature: Display Digital Twin Details
+Feature: Digital Twin - Container + Datat Sets
 
   @tag:noLogout
   Scenario: Load full example twin
     Given I log in to evan.network using vue
     When I click on "My Assets" in main menu
     Then I want to see a text including "Digital Twins"
-      And I want to see a text including "Full Example #2"
-    When I click on an element with text including "Full Example #2"
-      And I wait 15 seconds until loading was finished
+      And I want to see a text including "Full Example #3"
+    When I click on an element with text including "Full Example #3"
+      And I wait 30 seconds until loading was finished
 
   @tag:noLogout
   Scenario: all containers are listed
-    Then I want to see a text including "Full Example #2"
+    Then I want to see a text including "Full Example #3"
       And I want to see a text including "General"
-      And I want to see a text including "pluginLists"
       And I want to see a text including "pluginEntries"
+      And I want to see a text including "pluginEntriesValidation"
+      And I want to see a text including "pluginLists"
+      And I want to see a text including "pluginListsValidation"
 
   @tag:noLogout
   Scenario: list all pluginentries
@@ -59,21 +61,87 @@ Feature: Display Digital Twin Details
     Then The value of the Input field with label "textField" should be "gibberish"
     # object
     When I set Input field with label "objectField" to "gluposti"
-    Then I want to see a button "Save"
-      And I want to see a button "Cancel"
-      And I want to see a text including "Invalid JSON format."
+    Then I want to see a text including "Invalid JSON format."
     # And the button "Save" should be "disabled" #TODO
-    When I set Input field with label "objectField" to `{"new": "entry"}`
+    When I set Input field with label "objectField" to `{"new":"entry"}`
     Then I do not want to see a text including "Invalid JSON format."
-      And The value of the Input field with label "objectField" should be `{"new": "entry"}`
+      And The value of the Input field with label "objectField" should be `{"new":"entry"}`
     # Save button is enabled and twin is saved
     When I click on button "Save"
       And I wait 30 seconds until loading was finished
     Then I want to see a text including "Saving data ... completed"
       And The value of the Input field with label "numberField" should be "42"
       And The value of the Input field with label "textField" should be "gibberish"
-      And The value of the Input field with label "objectField" should be `{"new": "entry"}`
+      And The value of the Input field with label "objectField" should be `{"new":"entry"}`
       And The value of the Input field with id "dataset-input-checkboxEntry-primitive" should be "true"
+
+  @tag:noLogout
+  Scenario: check formular validation
+    When I click on "pluginEntriesValidation" in side navigation
+      And I wait 30 seconds until loading was finished
+      And I click on input field with label "numberField"
+    Then the button "Save" should be "disabled"
+    # number
+    When I set Input field with label "numberField" to "12345"
+    Then I want to see a text including "should be <= 123"
+    When I set Input field with label "numberField" to "0"
+    Then I want to see a text including "should be >= 1"
+    When I set Input field with label "numberField" to "123"
+    # text
+      And I set Input field with label "textField" to "gibberish gibberish gibberish"
+    Then I want to see a text including "should not be longer than 20 characters"
+    When I set Input field with label "textField" to ""
+    Then I want to see a text including "should not be shorter than 1 character"
+    When I set Input field with label "textField" to "gibberish"
+    # object
+      And I set Input field with label "objectField" to "gluposti"
+    Then I want to see a text including "Invalid JSON format."
+    When I set Input field with label "objectField" to `{}`
+    Then I want to see a text including "should have required property bar"
+    When I set Input field with label "objectField" to `{"bar": "123"}`
+    Then I want to see a text including "should be number"
+    When I set Input field with label "objectField" to `{"bar": 123, "minMax": ""}`
+    Then I want to see a text including "should not be shorter than 1 character"
+    When I set Input field with label "objectField" to `{"bar": 123, "minMax": "12345678901"}`
+    Then I want to see a text including "should not be longer than 10 characters"
+      And I set Input field with label "objectField" to `{"bar": 123, "minMax": "123"}`
+    # array
+    When I set Input field with label "arrayField" to "gluposti"
+    Then I want to see a text including "Invalid JSON format."
+    When I set Input field with label "arrayField" to `[]`
+    Then I want to see a text including "should not have less than 1 item"
+    When I set Input field with label "arrayField" to `[""]`
+    Then I want to see a text including "should be object"
+    When I set Input field with label "arrayField" to `[{},{},{},{},{},{},{}]`
+    Then I want to see a text including "should not have more than 5 items"
+    When I set Input field with label "arrayField" to `[{}]`
+    # files
+    Then I want to see a text including "should not have less than 1 item"
+    When I upload file "bicycle.json" to the dropzone with the id "dataset-input-objectEntry-filesField"
+      And I wait for 1 seconds
+      And I click on button "Save"
+      Then I wait 30 seconds until loading was finished
+
+  @tag:noLogout
+  Scenario: list all list plugin entries
+    When I click on "pluginListsValidation" in side navigation
+    Then I want to see a text including "listObject"
+    When I click the element with id "dataset-list-listObject-dropdown"
+    Then I want to see a text including "Show all"
+      And I want to see a text including "Add an Entry"
+    When I click the element with id "dataset-list-listObject-add"
+      And I wait for 1 seconds
+    When I set Input field with label "fieldNumber" to "123"
+      And I set Input field with label "fieldText" to "gibberish"
+      And I set Input field with label "objectField" to `{"bar": 123, "minMax": "123"}`
+      And I set Input field with label "arrayField" to `[{}]`
+      And I upload file "bicycle.json" to the dropzone with the id "dataset-input-listObject-fieldFiles"
+      And I wait for 1 seconds
+    Then the button "Add Entry" should be "enabled"
+    When I click on button "Add Entry"
+      And I wait 30 seconds until loading was finished
+    Then I want to see a text including "Saving data ... completed"
+
 
   Scenario: localization test with english
     Given I log in to evan.network using vue
@@ -98,7 +166,6 @@ Feature: Display Digital Twin Details
       And I want to see a text including "Country"
       And I want to see a text including "Post-Code"
       And I want to see a text including "Street & Number"
-
 
   @german
   Scenario: localization test with german
@@ -132,4 +199,4 @@ Feature: Display Digital Twin Details
 # Scenario: share functionality for every entry (will open the share data sidebar)
 # Scenario: quick navigation to entries on the right side (not on mobile or smaller screens)
 # Scenario: change files entry
-# Scenario: change list checkbox  entry
+# Scenario: change list checkbox entry

--- a/tests-e2e/test-utils/test-utils.js
+++ b/tests-e2e/test-utils/test-utils.js
@@ -101,7 +101,7 @@ export async function getElementIdByLabel(value) {
 }
 
 export async function getElementsCount(selector, mode = 'xpath') {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     client.elements(mode, selector, (result) => {
       console.log('Length', result.value.length); // (if there are 3 li, here should be a count of 3)
       resolve(result.value.length);
@@ -134,17 +134,14 @@ export function getSelector(label, angular) {
   if (!angular) {
     // support also the .input-wrapper element around the input
     const inputSelectors = [
-      'input', 'div/input',
-      'select', 'div/select',
-      'textarea', 'div/textarea',
+      'input',
+      'select',
+      'textarea',
     ];
 
-    return inputSelectors.map((inputSelector) => [
-      `//label[normalize-space(text()) = "${label}"]/preceding-sibling::${inputSelector}`,
-      `//label[normalize-space(text()) = "${label}"]/following-sibling::${inputSelector}`,
-      `//label/*[normalize-space(text()) = "${label}"]/parent::*/preceding-sibling::${inputSelector}`,
-      `//label/*[normalize-space(text()) = "${label}"]/parent::*/following-sibling::${inputSelector}`,
-    ].join('|')).join('|');
+    return inputSelectors
+      .map((inputSelector) => `//label[contains(., "${label}")]/parent::*//${inputSelector}`)
+      .join('|');
   }
 
   return [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,7 @@
     "strict": false,
     "strictFunctionTypes": false,
     "strictPropertyInitialization": false,
-    "target": "es2018"
+    "target": "es6"
   },
   "exclude": [
     "node_modules",
@@ -42,5 +42,9 @@
   ],
   "files": [
     "./scripts/dapp/vue-shim.d.ts"
+  ],
+  "include": [
+    "./src/**/*",
+    "./src/**/*.json"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,6 @@
     "declarationMap": true,
     "emitDeclarationOnly": true,
     "experimentalDecorators": true,
-    "lib": [
-      "es2015",
-      "dom"
-    ],
-    "module": "es2015",
     "moduleResolution": "node",
     "noImplicitAny": false,
     "paths": {
@@ -39,7 +34,7 @@
     "strict": false,
     "strictFunctionTypes": false,
     "strictPropertyInitialization": false,
-    "target": "es5"
+    "target": "es2018"
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Use es6 build for bcc webpack and dapps. We can use browser native `async` / `await`, that makes the loading of dapps, especially for the bcc, much faster.  

- [CORE-950]

[CORE-950]: https://evannetwork.atlassian.net/browse/CORE-950